### PR TITLE
Fix issues with create-dmg

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*	text=auto
+create-dmg text eol=lf

--- a/pbt/installer/mac/__init__.py
+++ b/pbt/installer/mac/__init__.py
@@ -15,6 +15,11 @@ def create_installer_mac():
         dest_bu = dest + ".bu"
         replace(dest, dest_bu)
     try:
+		check_call([
+			"chmod",
+			"755",
+			join(dirname(__file__), "create-dmg", "create-dmg")
+		], stdout=DEVNULL)
         pdata = [
             join(dirname(__file__), "create-dmg", "create-dmg"),
             "--volname",


### PR DESCRIPTION
Added gitattributes to make sure create-dmg only has LF endings.
Added execute permissions to create-dmg